### PR TITLE
Update urlparse and shebang

### DIFF
--- a/sqlmapcli/task.py
+++ b/sqlmapcli/task.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -12,7 +12,7 @@
 """
 
 import time
-from urlparse import urljoin
+from urllib.parse import urljoin
 
 import requests
 


### PR DESCRIPTION
Urlparse in Python 2.7.11 was renamed to urllib.parse in Python 3 (same as client.py)